### PR TITLE
Fix manualtasks

### DIFF
--- a/inc/Service/Manualtask.php
+++ b/inc/Service/Manualtask.php
@@ -47,16 +47,18 @@ class PostFinanceCheckoutServiceManualtask extends PostFinanceCheckoutServiceAbs
         );
         foreach (Shop::getShops(true, null, true) as $shopId) {
             $spaceId = Configuration::get(PostFinanceCheckoutBasemodule::CK_SPACE_ID, null, null, $shopId);
-            if ($spaceId && ! in_array($spaceId, $spaceIds)) {
-                $shopNumberOfManualTasks = $manualTaskService->count(
-                    $spaceId,
-                    $this->createEntityFilter('state', \PostFinanceCheckout\Sdk\Model\ManualTaskState::OPEN)
-                );
-                Configuration::updateValue(self::CONFIG_KEY, $shopNumberOfManualTasks, false, null, $shopId);
-                if ($shopNumberOfManualTasks > 0) {
-                    $numberOfManualTasks[$shopId] = $shopNumberOfManualTasks;
+            if ($spaceId) {
+                if (!in_array($spaceId, $spaceIds)) {
+                    $shopNumberOfManualTasks = $manualTaskService->count(
+                        $spaceId,
+                        $this->createEntityFilter('state', \PostFinanceCheckout\Sdk\Model\ManualTaskState::OPEN)
+                    );
+                    Configuration::updateValue(self::CONFIG_KEY, $shopNumberOfManualTasks, false, null, $shopId);
+                    if ($shopNumberOfManualTasks > 0) {
+                        $numberOfManualTasks[$shopId] = $shopNumberOfManualTasks;
+                    }
+                    $spaceIds[] = $spaceId;
                 }
-                $spaceIds[] = $spaceId;
             } else {
                 Configuration::updateValue(self::CONFIG_KEY, 0, false, null, $shopId);
             }

--- a/inc/Service/Manualtask.php
+++ b/inc/Service/Manualtask.php
@@ -46,21 +46,22 @@ class PostFinanceCheckoutServiceManualtask extends PostFinanceCheckoutServiceAbs
             PostFinanceCheckoutHelper::getApiClient()
         );
         foreach (Shop::getShops(true, null, true) as $shopId) {
-            $spaceId = Configuration::get(PostFinanceCheckoutBasemodule::CK_SPACE_ID, null, null, $shopId);
+            $shopGroupId = Shop::getGroupFromShop($shopId);
+            $spaceId = Configuration::get(PostFinanceCheckoutBasemodule::CK_SPACE_ID, null, $shopGroupId, $shopId);
             if ($spaceId) {
                 if (!in_array($spaceId, $spaceIds)) {
                     $shopNumberOfManualTasks = $manualTaskService->count(
                         $spaceId,
                         $this->createEntityFilter('state', \PostFinanceCheckout\Sdk\Model\ManualTaskState::OPEN)
                     );
-                    Configuration::updateValue(self::CONFIG_KEY, $shopNumberOfManualTasks, false, null, $shopId);
+                    Configuration::updateValue(self::CONFIG_KEY, $shopNumberOfManualTasks, false, $shopGroupId, $shopId);
                     if ($shopNumberOfManualTasks > 0) {
                         $numberOfManualTasks[$shopId] = $shopNumberOfManualTasks;
                     }
                     $spaceIds[] = $spaceId;
                 }
             } else {
-                Configuration::updateValue(self::CONFIG_KEY, 0, false, null, $shopId);
+                Configuration::updateValue(self::CONFIG_KEY, 0, false, $shopGroupId, $shopId);
             }
         }
         return $numberOfManualTasks;


### PR DESCRIPTION
This PR fixes https://github.com/pfpayments/prestashop-1.6/issues/7

- It will update the setting `PFC_MANUAL_TASKS` only for shops where the module is configured with a `spaceId`.
- It will save the correct setting with the correct `id_shop_group`

Thank you for considering accepting this PR or fixing the problem on your side.