### PR TITLE
Fix error: Cannot read properties of undefined (self).

### DIFF
--- a/views/js/frontend/checkout.js
+++ b/views/js/frontend/checkout.js
@@ -87,8 +87,8 @@ jQuery(function ($) {
 
 
         handler_submit : function (event) {
+            var self = event.data.self;
             if(!self.processing) {
-                var self = event.data.self;
                 self.disable_pay_button();
 
                 var tosInput = $('#cgv');


### PR DESCRIPTION
This PR fixes partially https://github.com/pfpayments/prestashop-1.6/issues/5:
- It fixes the Javascript error mentionned under point 7.
- It does not fix the other problems though (display issues and functionality of the buttons).

```
 checkout.js:90 Uncaught TypeError: Cannot read properties of undefined (reading 'processing')
 at HTMLButtonElement.handler_submit (checkout.js:90:22)
 at HTMLButtonElement.dispatch (jquery-1.11.0.min.js:3:8066)
 at HTMLButtonElement.r.handle (jquery-1.11.0.min.js:3:4767)
```