### PR TITLE
Every Exception needs a message.

### DIFF
--- a/inc/Exception/Incompleteconfig.php
+++ b/inc/Exception/Incompleteconfig.php
@@ -14,4 +14,8 @@
  */
 class PostFinanceCheckoutExceptionIncompleteconfig extends Exception
 {
+    public function __construct()
+    {
+        parent::__construct("Postfinance Checkout's configuration is incomplete.");
+    }
 }


### PR DESCRIPTION
This PR sets a standard message for `PostFinanceCheckoutExceptionIncompleteconfig`.
Fixes https://github.com/pfpayments/prestashop-1.6/issues/8